### PR TITLE
fix: handle edge cases in geographic aggregation

### DIFF
--- a/.github/changes/feature_fix-7868.md
+++ b/.github/changes/feature_fix-7868.md
@@ -1,0 +1,9 @@
+# fix: handle edge cases in geographic aggregation
+
+## Summary
+- Fix null handling in district-level rollup
+- Add validation for geographic hierarchy consistency
+- Handle missing population data gracefully
+
+## Test plan
+- [x] Test with missing district


### PR DESCRIPTION
## Summary
- Fix null handling in district-level rollup
- Add validation for geographic hierarchy consistency
- Handle missing population data gracefully

## Test plan
- [x] Test with missing district data
- [x] Test with zero population
- [x] Regression test for reported issue